### PR TITLE
I've fixed various test failures for Day 4 finalization.

### DIFF
--- a/smart-maintenance-saas/apps/agents/core/data_acquisition_agent.py
+++ b/smart-maintenance-saas/apps/agents/core/data_acquisition_agent.py
@@ -34,18 +34,20 @@ class DataAcquisitionAgent(BaseAgent):
         self.logger = logger if logger else logging.getLogger(f"{__name__}.{self.agent_id}")
         self.logger.info(f"DataAcquisitionAgent {self.agent_id} initialized.")
 
-    def start(self):
+    async def start(self) -> None:
         """
         Subscribes the agent to relevant events.
         """
-        self.event_bus.subscribe(SensorDataReceivedEvent, self.process)
+        await super().start()
+        await self.event_bus.subscribe(SensorDataReceivedEvent.__name__, self.process)
         self.logger.info(f"DataAcquisitionAgent {self.agent_id} started and subscribed to SensorDataReceivedEvent.")
 
-    def stop(self):
+    async def stop(self) -> None:
         """
         Unsubscribes the agent from events.
         """
-        self.event_bus.unsubscribe(SensorDataReceivedEvent, self.process)
+        await super().stop()
+        await self.event_bus.unsubscribe(SensorDataReceivedEvent.__name__, self.process)
         self.logger.info(f"DataAcquisitionAgent {self.agent_id} stopped and unsubscribed from SensorDataReceivedEvent.")
 
     async def process(self, event: SensorDataReceivedEvent):

--- a/smart-maintenance-saas/core/events/event_bus.py
+++ b/smart-maintenance-saas/core/events/event_bus.py
@@ -90,4 +90,4 @@ class EventBus:
                         f"Traceback: {traceback.format_exc()}"
                     )
         else:
-            logger.debug(f"No subscribers for event type name '{event_type_name}'.")
+            logger.debug(f"No subscribers for event type {event_type_name}")

--- a/smart-maintenance-saas/tests/conftest.py
+++ b/smart-maintenance-saas/tests/conftest.py
@@ -74,12 +74,12 @@ def test_db_url(postgres_container) -> str:
         # Use a direct connection to an existing test database
         return os.environ.get("DATABASE_TEST_URL", settings.database_url.replace(
             settings.db_name, f"{settings.db_name}_test"
-        ))
+        )).replace("postgresql://", "postgresql+asyncpg://")
     else:
         # Default to a test database on the development server
         return settings.database_url.replace(
             settings.db_name, f"{settings.db_name}_test"
-        )
+        ).replace("postgresql://", "postgresql+asyncpg://")
 
 
 @pytest.fixture(scope="session")

--- a/smart-maintenance-saas/tests/integration/agents/core/test_data_acquisition_agent.py
+++ b/smart-maintenance-saas/tests/integration/agents/core/test_data_acquisition_agent.py
@@ -38,7 +38,7 @@ class TestIntegrationDataAcquisitionAgent(unittest.IsolatedAsyncioTestCase):
             logger=self.logger # Pass the MagicMock logger
         )
         # The agent's start method subscribes it to SensorDataReceivedEvent
-        self.agent.start() # Changed from await self.agent.start() as agent's start() is not async
+        await self.agent.start()
 
         self.received_events = []
         # Ensure the handler can be awaited if the event bus publish/dispatch mechanism is async
@@ -51,7 +51,7 @@ class TestIntegrationDataAcquisitionAgent(unittest.IsolatedAsyncioTestCase):
 
     async def asyncTearDown(self):
         if self.agent:
-            self.agent.stop() # Changed from await self.agent.stop() as agent's stop() is not async
+            await self.agent.stop()
 
     async def test_integration_success_path(self):
         correlation_id = uuid.uuid4()

--- a/smart-maintenance-saas/tests/unit/core/test_event_bus.py
+++ b/smart-maintenance-saas/tests/unit/core/test_event_bus.py
@@ -83,7 +83,7 @@ async def test_publish_no_subscribers(caplog):
     await event_bus.publish(event_type, event_data)
     # No assertion needed for handler calls, just that no error occurs
     # Check for the specific debug log message
-    assert f"No subscribers for event '{event_type}'" in caplog.text
+    assert f"No subscribers for event type {event_type}" in caplog.text
     logger.info("test_publish_no_subscribers: PASSED (verified via log)")
 
 


### PR DESCRIPTION
I addressed the following issues:
- `sqlalchemy.exc.InvalidRequestError`: I ensured the `asyncpg` driver is used by the `test_db_url` fixture in `tests/conftest.py` for all paths.
- DataAcquisitionAgent integration test failures:
    - I made the `DataAcquisitionAgent.start/stop` methods asynchronous.
    - I ensured `agent.start/stop` call `super().start/stop`.
    - I corrected the event subscription in the agent to use `event.__class__.__name__`.
    - I updated the integration tests to await the asynchronous agent start/stop.
- `test_publish_no_subscribers` failure:
    - I modified the `EventBus` log message for no subscribers to remove quotes and simplify it.
    - I updated the corresponding assertion in the unit test to match the new log format.

These changes aim to resolve the 5 failed tests and 1 error reported by pytest.